### PR TITLE
fix(noticket): more auth fixes

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -50,9 +50,27 @@ function App() {
 
   useEffect(() => {
     const storedToken = localStorage.getItem('plexAuthToken');
+
     if (storedToken) {
-      setToken(storedToken);
-    }
+      fetch('/validateToken', {
+        headers: {
+          'x-access-token': storedToken,
+        },
+      })
+        .then((response) => {
+          if (response.ok) {
+            setToken(storedToken);
+          } else {
+            localStorage.removeItem('plexAuthToken');
+            setToken(null);
+          }
+        })
+        .catch(() => {
+          localStorage.removeItem('plexAuthToken');
+          setToken(null);
+        });
+      }
+
     // Fetch the current release version from the server
     axios
       .get('/getCurrentReleaseVersion')

--- a/client/src/components/PLexAuth.tsx
+++ b/client/src/components/PLexAuth.tsx
@@ -21,6 +21,9 @@ const PlexAuth: React.FC<PlexAuthProps> = ({ setToken }) => {
         authWindow.focus();
       }
 
+      let attempts = 0;
+      const maxAttempts = 5;
+
       // Poll the server every 5 seconds to check if the PIN is claimed
       const intervalId = setInterval(async () => {
         const res = await fetch(`/plex/check-pin/${pinId}`);
@@ -31,6 +34,13 @@ const PlexAuth: React.FC<PlexAuthProps> = ({ setToken }) => {
           localStorage.setItem("plexAuthToken", authToken);
           authWindow?.close();
           window.location.href = "/configuration";
+        } else {
+          attempts++;
+          if (attempts >= maxAttempts) {
+            clearInterval(intervalId);
+            setError("Failed to authenticate with Plex. Please try again.");
+            authWindow?.close();
+          }
         }
       }, 5000);
     } catch (error: any) {

--- a/server/server.js
+++ b/server/server.js
@@ -131,6 +131,10 @@ const initialize = async () => {
       }
     });
 
+    app.get('/validateToken', verifyToken, (req, res) => {
+      res.json({ valid: true });
+    });
+
     // Not sure if this is needed, but lets expose it for now for testing
     app.get('/refreshlibrary', verifyToken, () => {
       plexModule.refreshLibrary();


### PR DESCRIPTION
* Allow new user to login and set their token
* Show error message to user if they try to login with wrong plex account
* Do not allow infinite retry attempts for auth
* Do not allow access to protected React routes with invalid token/login